### PR TITLE
Ignore ssl and report errors

### DIFF
--- a/follow-redirect-url.js
+++ b/follow-redirect-url.js
@@ -1,78 +1,128 @@
-'use strict';
+"use strict";
 
-const fetch = require('node-fetch');
+const fetch = require("node-fetch");
+const https = require("https");
+const http = require("http");
 fetch.Promise = Promise;
 
-const prefixWithHttp = url => {
-    let pattern = new RegExp('^http');
-    return pattern.test(url) ? url : 'http://' + url;
+const prefixWithHttp = (url) => {
+  let pattern = new RegExp("^http");
+  return pattern.test(url) ? url : "http://" + url;
 };
 
-const isRedirect = status => status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+const isRedirect = (status) =>
+  status === 301 ||
+  status === 302 ||
+  status === 303 ||
+  status === 307 ||
+  status === 308;
 
-const extractMetaRefreshUrl = html => {
-    const metaRefreshPattern = '(CONTENT|content)=["\']0;[ ]*(URL|url)=(.*?)(["\']\s*>)';
-    let match = html.match(metaRefreshPattern);
-    return match && match.length == 5 ? match[3] : null;
+const extractMetaRefreshUrl = (html) => {
+  const metaRefreshPattern =
+    "(CONTENT|content)=[\"']0;[ ]*(URL|url)=(.*?)([\"']s*>)";
+  let match = html.match(metaRefreshPattern);
+  return match && match.length == 5 ? match[3] : null;
 };
 
-const visit = (url, fetchOptions) => new Promise((resolve, reject) => {
+const visit = (url, fetchOptions) =>
+  new Promise((resolve, reject) => {
     url = prefixWithHttp(url);
-    fetch(url, fetchOptions).then(response => {
+    fetch(url, fetchOptions)
+      .then((response) => {
         if (isRedirect(response.status)) {
-            const location = response.headers.get('location');
-            if (!location) {
-                throw `${url} responded with status ${response.status} but no location header`;
-            };
-            resolve({ url: url, redirect: true, status: response.status, redirectUrl: response.headers.get('location') });
+          const location = response.headers.get("location");
+          if (!location) {
+            throw `${url} responded with status ${response.status} but no location header`;
+          }
+          resolve({
+            url: url,
+            redirect: true,
+            status: response.status,
+            redirectUrl: response.headers.get("location"),
+          });
         } else if (response.status == 200) {
-            response.text().then(text => {
-                const redirectUrl = extractMetaRefreshUrl(text);
-                resolve(redirectUrl ?
-                    { url: url, redirect: true, status: '200 + META REFRESH', redirectUrl: redirectUrl } :
-                    { url: url, redirect: false, status: response.status });
-            });
+          response.text().then((text) => {
+            const redirectUrl = extractMetaRefreshUrl(text);
+            resolve(
+              redirectUrl
+                ? {
+                    url: url,
+                    redirect: true,
+                    status: "200 + META REFRESH",
+                    redirectUrl: redirectUrl,
+                  }
+                : { url: url, redirect: false, status: response.status }
+            );
+          });
         } else {
-            resolve({ url: url, redirect: false, status: response.status });
-        };
-    }).catch(reject);
-});
-
-const _startFollowingRecursively = (url, options = {}, count = 1, visits = []) => new Promise((resolve, reject) => {
-    //Default max_redirect_length = 20 and request_timeout = 10000 ms
-    const { max_redirect_length = 20, request_timeout = 10000 } = options;
-    const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36';
-    const fetchOptions = {
-        redirect: 'manual',
-        follow: 0,
-        timeout: request_timeout,
-        headers: {
-            'User-Agent': userAgent,
-            'Accept': 'text/html'
+          resolve({ url: url, redirect: false, status: response.status });
         }
+      })
+      .catch(reject);
+  });
+
+const _startFollowingRecursively = (
+  url,
+  options = {},
+  count = 1,
+  visits = []
+) =>
+  new Promise((resolve, reject) => {
+    //Default max_redirect_length = 20 and request_timeout = 10000 ms
+    const {
+      max_redirect_length = 20,
+      request_timeout = 10000,
+      ignoreSslErrors = false,
+    } = options;
+    const userAgent =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36";
+    const fetchOptions = {
+      redirect: "manual",
+      follow: 0,
+      timeout: request_timeout,
+      headers: {
+        "User-Agent": userAgent,
+        Accept: "text/html",
+      },
+      // https://stackoverflow.com/questions/52478069/node-fetch-disable-ssl-verification
+      agent: (parsedUrl) => {
+        if (parsedUrl.protocol == "https:") {
+          return new https.Agent({
+            rejectUnauthorized: !ignoreSslErrors,
+          });
+        } else {
+          return new http.Agent();
+        }
+      }
     };
 
     if (count > max_redirect_length) {
-        return reject(`Exceeded max redirect depth of ${max_redirect_length}`);
-    };
+      return reject(`Exceeded max redirect depth of ${max_redirect_length}`);
+    }
 
-    visit(url, fetchOptions).then(response => {
+    visit(url, fetchOptions)
+      .then((response) => {
         count++;
         visits.push(response);
         url = response.redirectUrl;
-        resolve(response.redirect ? _startFollowingRecursively(url, options, count, visits) : visits);
-
-    }).catch(error => {
-        visits.push({ url: url, redirect: false, status: `Error: ${error}` });
+        resolve(
+          response.redirect
+            ? _startFollowingRecursively(url, options, count, visits)
+            : visits
+        );
+      })
+      .catch((error) => {
+        visits.push({ url: url, redirect: false, error: error.code, status: `Error: ${error}` });
         resolve(visits);
-    });
-});
+      });
+  });
 
 /**
- * 
+ *
  * @param {String} url - pass url like http://google.com
- * @param {Object} options - optional configuration eg:{ max_redirect_length:20, request_timeout:10000 } 
+ * @param {Object} options - optional configuration eg:{ max_redirect_length:20, request_timeout:10000 }
  * @param {Number} options.max_redirect_length - set max redirect limit Default 20
  * @param {Number} options.request_timeout - request timeout in milliseconds Default 10000 ms
  */
-module.exports.startFollowing = (url, options) => _startFollowingRecursively(url, options);
+module.exports.startFollowing = (url, options) =>
+  _startFollowingRecursively(url, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -810,9 +810,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "nyc": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple command-line utility that lets you follow redirects to see where http URLs end up. Useful for shortened URLs.",
   "main": "lib.js",
   "dependencies": {
-    "node-fetch": "^2.3.0"
+    "node-fetch": "^2.4.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -45,6 +45,10 @@
     {
       "name": "Sayed Tauseef Naqvi",
       "email": "tauseef.naqvi786@gmail.com"
+    },
+    {
+      "name": "Michael Bianco",
+      "email": "mike@mikebian.co"
     }
   ],
   "preferGlobal": true,

--- a/test/test.js
+++ b/test/test.js
@@ -72,11 +72,18 @@ describe('follow-redirect-url', () => {
     });
   });
 
-  // it('should reject invalid URLs', () => {//TODO: Do it later
-  //   return follower.startFollowing('bogus://something').then(visits => {
-  //     return expect(visits).to.eventually.be.rejected;
-  //   });
-  // });
+  it('should reject invalid URLs', () => {
+    return follower.startFollowing('bogus://something').then(visits => {
+      return expect(visits).to.deep.equal([
+          {
+            "error": "ENOTFOUND",
+            "redirect": false,
+            "status": "Error: FetchError: request to http://bogus//something failed, reason: getaddrinfo ENOTFOUND bogus",
+            "url": "bogus://something"
+          }
+        ])
+    });
+  });
 
   const expectedStatusCodesOnly = [
     {


### PR DESCRIPTION
There are more changes than I would like in this PR because `prettier` autoformatted the code. There are two main changes here:

* Adds a `ignoreSslErrors` param
* If a redirect errors out, the error information is included in the response