### PR TITLE
feat(cli): add support for custom HTTP headers

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -4,6 +4,51 @@
 
 const followRedirect = require("./follow-redirect-url");
 
+const parseHeaderPair = (s) => {
+  const idx = s.indexOf(":");
+  if (idx === -1) {
+    throw new Error(
+      `Invalid header ${JSON.stringify(s)} (expected "Name: value")`,
+    );
+  }
+  const name = s.slice(0, idx).trim();
+  const value = s.slice(idx + 1).trim();
+  if (!name) {
+    throw new Error(`Invalid header ${JSON.stringify(s)} (empty name)`);
+  }
+  return [name, value];
+};
+
+const parseArgs = (argv) => {
+  const headers = {};
+  let url = "";
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+
+    if (a === "-H") {
+      const v = argv[i + 1];
+      if (!v) throw new Error(`Missing value for ${a}`);
+      i++;
+      const [k, val] = parseHeaderPair(String(v));
+      headers[k] = headers[k] ? `${headers[k]}, ${val}` : val;
+      continue;
+    }
+
+    if (a.startsWith("-")) {
+      throw new Error(`Unknown option ${JSON.stringify(a)}`);
+    }
+
+    if (url)
+      throw new Error(
+        `Multiple URLs provided: ${JSON.stringify(url)} and ${JSON.stringify(a)}`,
+      );
+    url = a;
+  }
+
+  return { url, headers };
+};
+
 const follow = (url) =>
   followRedirect
     .startFollowing(url)
@@ -12,14 +57,31 @@ const follow = (url) =>
         .map((v) =>
           v.redirect
             ? `${v.url} -> ${v.status}`
-            : `${v.url} -> ${v.status || ""}`
+            : `${v.url} -> ${v.status || ""}`,
         )
-        .forEach((v) => console.log(v))
+        .forEach((v) => console.log(v)),
     );
 
-const url = process.argv[2];
-if (!url) {
-  console.log("Usage: follow <URL>");
-  process.exit(1);
+try {
+  const { url, headers } = parseArgs(process.argv);
+  if (!url) {
+    console.log('Usage: follow <URL> [-H "Header: value"]...');
+    process.exit(1);
+  }
+
+  const options = Object.keys(headers).length > 0 ? { headers } : undefined;
+  followRedirect
+    .startFollowing(url, options)
+    .then((visits) =>
+      visits
+        .map((v) =>
+          v.redirect
+            ? `${v.url} -> ${v.status}`
+            : `${v.url} -> ${v.status || ""}`,
+        )
+        .forEach((v) => console.log(v)),
+    );
+} catch (e) {
+  console.error(e.message || String(e));
+  process.exit(2);
 }
-follow(url);

--- a/follow-redirect-url.js
+++ b/follow-redirect-url.js
@@ -50,7 +50,7 @@ const visit = (url, fetchOptions) =>
                     status: "200 + META REFRESH",
                     redirectUrl: redirectUrl,
                   }
-                : { url: url, redirect: false, status: response.status }
+                : { url: url, redirect: false, status: response.status },
             );
           });
         } else {
@@ -64,13 +64,14 @@ const _startFollowingRecursively = (
   url,
   options = {},
   count = 1,
-  visits = []
+  visits = [],
 ) =>
   new Promise((resolve, reject) => {
     const {
       max_redirect_length = 20,
       request_timeout = 10000,
       ignoreSslErrors = false,
+      headers: extraHeaders = {},
     } = options;
     const userAgent =
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36";
@@ -81,6 +82,7 @@ const _startFollowingRecursively = (
       headers: {
         "User-Agent": userAgent,
         Accept: "text/html",
+        ...extraHeaders,
       },
       // https://stackoverflow.com/questions/52478069/node-fetch-disable-ssl-verification
       agent: (parsedUrl) => {
@@ -91,7 +93,7 @@ const _startFollowingRecursively = (
         } else {
           return new http.Agent();
         }
-      }
+      },
     };
 
     if (count > max_redirect_length) {
@@ -106,11 +108,16 @@ const _startFollowingRecursively = (
         resolve(
           response.redirect
             ? _startFollowingRecursively(url, options, count, visits)
-            : visits
+            : visits,
         );
       })
       .catch((error) => {
-        visits.push({ url: url, redirect: false, error: error.code, status: `Error: ${error}` });
+        visits.push({
+          url: url,
+          redirect: false,
+          error: error.code,
+          status: `Error: ${error}`,
+        });
         resolve(visits);
       });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,13 @@ describe('follow-redirect-url', () => {
     });
   });
 
+  it('should attach custom headers to requests', () => {
+    const options = { headers: { 'X-Test': '1' } };
+    return follower.startFollowing('http://localhost:9000/needs-header', options).then(visits => {
+      expect(visits[0].status).to.equal(200);
+    });
+  });
+
   it('should reject invalid URLs', () => {
     return follower.startFollowing('bogus://something').then(visits => {
       return expect(visits).to.deep.oneOf([

--- a/test/webserver.js
+++ b/test/webserver.js
@@ -10,6 +10,14 @@ const start = () => {
 
   app.get('/meta', (req, res) => res.send('<META http-equiv="refresh" content="0; url=http://localhost:9000/1">'));
 
+  app.get('/needs-header', (req, res) => {
+    if (req.get('X-Test') === '1') {
+      res.send("ok");
+    } else {
+      res.status(400).send("missing header");
+    }
+  });
+
   app.get('/:number', (req, res) => {
     let number = req.params.number;
     if (number > 1) {


### PR DESCRIPTION
Allow passing custom headers via the -H flag in the CLI and through the API options. This enables users to send headers like X-Test for endpoints that require them.

- Add headers option to startFollowing API
- Implement CLI argument parsing for -H "Name: value"
- Update test suite to verify header functionality